### PR TITLE
Add constraint on messaging contact

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -5,7 +5,7 @@ import os
 
 
 from sqlalchemy import or_
-from app.models import Profile, Interest, User, Likes, Story
+from app.models import Profile, Interest, User, Likes, Story, Conversation
 
 from math import radians, sin, cos, sqrt, atan2
 
@@ -749,16 +749,32 @@ def messages():
     contacts = []
 
     if current_profile:
-        candidate_profiles = (
-            Profile.query
-            .filter(Profile.id != current_profile.id)
-            .order_by(Profile.display_name)
+        conversations = (
+            Conversation.query
+            .filter(or_(
+                Conversation.profile1_id == current_profile.id,
+                Conversation.profile2_id == current_profile.id
+            ))
+            .order_by(Conversation.created_at.desc())
             .all()
         )
 
+        contact_ids = [
+            conversation.profile2_id
+            if conversation.profile1_id == current_profile.id
+            else conversation.profile1_id
+            for conversation in conversations
+        ]
+
+        profiles_by_id = {
+            profile.id: profile
+            for profile in Profile.query.filter(Profile.id.in_(contact_ids)).all()
+        } if contact_ids else {}
+
         contacts = [
-            profile_to_card(profile)
-            for profile in candidate_profiles
+            profile_to_card(profiles_by_id[contact_id])
+            for contact_id in contact_ids
+            if contact_id in profiles_by_id
         ]
 
     return render_template(


### PR DESCRIPTION
## Description

This PR updates the Messages page so that it only displays users who already have a conversation with the current user. Previously, the page listed every other profile in the system, even if no conversation existed.

## Main Changes

- Imported `Conversation` in `app/routes.py`.
- Updated the `/messages` route to query conversations where the current profile is either `profile1_id` or `profile2_id`.
- Extracted the other participant from each conversation.
- Loaded those profiles and converted them into contact cards.
- Preserved conversation ordering by newest conversation first.
- Kept the existing messaging logic unchanged.

## Notes

- No messaging restriction was added, users can still message any other user through the existing socket logic.
- No new conversation creation logic was added.
- Existing conversation creation remains handled by `get_or_create_conversation()` in `app/sockets.py`.

## Future Tasks

- Add a “Send Message” button on the profile page.
- Make the button open the Messages page with the selected profile active.
- Decide whether `chat:join` should create a conversation immediately, or only after the first message is sent.
