### PR TITLE
Add matches page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -685,7 +685,90 @@ def update_story():
 @login_required
 @profile_required
 def matches():
-    return "Matches page placeholder"
+    return render_template(
+        "matches.html",
+        is_logged_in=True
+    )
+
+@app.route("/api/matches")
+@login_required
+@profile_required
+def api_matches():
+    likes = Likes.query.filter_by(
+        liked_id=current_user.profile.id
+    ).all()
+
+    liker = []
+
+    for like in likes:
+        liker_profile = Profile.query.get(like.liker_id)
+
+        if liker_profile:
+            liker.append(profile_to_card(liker_profile))
+    
+
+    liked_likes = Likes.query.filter_by(
+        liker_id=current_user.profile.id
+    ).all()
+
+    liked = []
+
+    for like in liked_likes:
+        liked_profile = Profile.query.get(like.liked_id)
+
+        if liked_profile:
+            liked.append(profile_to_card(liked_profile))
+
+
+
+    return jsonify({
+        "likerprofiles": liker,
+        "likedprofiles": liked
+
+    })
+
+# def api_matches():
+#     my_profile_id = current_user.profile.id
+
+#     # People who liked me
+#     liked_you_likes = Likes.query.filter_by(
+#         liked_id=my_profile_id
+#     ).all()
+
+#     liked_you_profiles = []
+#     liked_you_ids = set()
+
+#     for like in liked_you_likes:
+#         profile = Profile.query.get(like.liker_id)
+
+#         if profile:
+#             liked_you_profiles.append(profile_to_card(profile))
+#             liked_you_ids.add(profile.id)
+
+#     # People I liked
+#     you_liked_likes = Likes.query.filter_by(
+#         liker_id=my_profile_id
+#     ).all()
+
+#     you_liked_profiles = []
+
+#     for like in you_liked_likes:
+#         # Do not show here if they already liked me
+#         if like.liked_id in liked_you_ids:
+#             continue
+
+#         profile = Profile.query.get(like.liked_id)
+
+#         if profile:
+#             you_liked_profiles.append(profile_to_card(profile))
+
+#     return jsonify({
+#         "liked_you": liked_you_profiles,
+#         "you_liked": you_liked_profiles
+#     })
+
+
+
 
 
 @app.route("/messages", methods=["GET", "POST"])

--- a/app/static/css/profile.css
+++ b/app/static/css/profile.css
@@ -23,7 +23,7 @@
 }
 
 .btn-like {
-  background-color: #e94e77; /* Your signature pink */
+  background-color: #e94e77;
   color: white;
   padding: 8px 20px;
   border-radius: 100px;
@@ -32,10 +32,13 @@
   font-size: 1.2rem;
   transition: all 0.3s ease;
   cursor: pointer;
-  display: flex;
+
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
+
+  text-decoration: none; /* remove underline */
 }
 
 /* Hover State */

--- a/app/static/js/matches.js
+++ b/app/static/js/matches.js
@@ -1,0 +1,130 @@
+function displayProfiles(profiles, listId, emptyMessage) {
+  const profileList = document.getElementById(listId);
+  profileList.innerHTML = "";
+
+  if (!profiles || profiles.length === 0) {
+    profileList.innerHTML = `<p class="text-muted">${emptyMessage}</p>`;
+    return;
+  }
+
+  profiles.forEach(profile => {
+    const distanceText =
+      profile.distance !== undefined && profile.distance !== null
+        ? ` · ${profile.distance} km away`
+        : "";
+
+    const card = `
+      <div class="col-md-4">
+        <div class="card profilecard-custom">
+          <img 
+            src="${profile.image}" 
+            class="card-img-top uniform-img" 
+            alt="${profile.name}"
+          >
+
+          <div class="card-body">
+            <h5 class="card-title">${profile.name}, ${profile.age}</h5>
+            <p class="card-text text-muted">${profile.location || ""}${distanceText}</p>
+
+            <div class="mb-3 profile-card-interests">
+              ${(profile.interests || []).map(interest => `
+                <span class="tag">${interest}</span>
+              `).join("")}
+            </div>
+
+            <a href="/profile/${profile.id}" class="btn btn-primary-custom w-100" style="font-size: 1rem;">
+              View Profile
+            </a>
+          </div>
+        </div>
+      </div>
+    `;
+
+    profileList.innerHTML += card;
+  });
+}
+
+fetch("/api/matches")
+  .then(response => response.json())
+  .then(data => {
+    displayProfiles(
+      data.likerprofiles,
+      "likedYouList",
+      "Users who like your profile will show up here."
+    );
+
+    displayProfiles(
+      data.likedprofiles,
+      "youLikedList",
+      "Profiles you like will show up here."
+    );
+  })
+  .catch(error => {
+    console.error("Error loading matches:", error);
+
+    document.getElementById("likedYouList").innerHTML =
+      "<p>Could not load users who liked you.</p>";
+
+    document.getElementById("youLikedList").innerHTML =
+      "<p>Could not load profiles you liked.</p>";
+  });
+
+
+
+
+// function displayProfiles(profiles) {
+//   const profileList = document.getElementById("profileList");
+//   profileList.innerHTML = "";
+
+//   if (!profiles || profiles.length === 0) {
+//     profileList.innerHTML = "<p>No users have liked you yet.</p>";
+//     return;
+//   }
+
+//   profiles.forEach(profile => {
+//     const distanceText =
+//       profile.distance !== undefined && profile.distance !== null
+//         ? ` · ${profile.distance} km away`
+//         : "";
+
+//     const card = `
+//       <div class="col-md-4">
+//         <div class="card profilecard-custom">
+//           <img 
+//             src="${profile.image}" 
+//             class="card-img-top uniform-img" 
+//             alt="${profile.name}"
+//           >
+
+//           <div class="card-body">
+//             <h5 class="card-title">${profile.name}, ${profile.age}</h5>
+//             <p class="card-text text-muted">${profile.location || ""}${distanceText}</p>
+
+//             <div class="mb-3 profile-card-interests">
+//               ${(profile.interests || []).map(interest => `
+//                 <span class="tag">${interest}</span>
+//               `).join("")}
+//             </div>
+
+//             <a href="/profile/${profile.id}" class="btn btn-primary-custom w-100" style="font-size: 1rem;">
+//               View Profile
+//             </a>
+//           </div>
+//         </div>
+//       </div>
+//     `;
+
+//     profileList.innerHTML += card;
+//   });
+// }
+
+// fetch("/api/matches")
+//   .then(response => response.json())
+//   .then(data => {
+//     displayProfiles(data.profiles);
+//   })
+//   .catch(error => {
+//     console.error("Error loading matches:", error);
+//     document.getElementById("profileList").innerHTML =
+//       "<p>Could not load matches.</p>";
+//   });

--- a/app/templates/matches.html
+++ b/app/templates/matches.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}HeartLink | Matches{% endblock %}
+
+{% block extra_head %}
+<style>
+  body {
+    background-color: #f8f6f7;
+    font-family: Arial, sans-serif;
+  }
+
+  .matches-header {
+    background: linear-gradient(135deg, #f3c6d8, #ffffff);
+    border-radius: 20px;
+    padding: 35px;
+    margin-top: 30px;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<main class="container">
+
+  <section class="matches-header">
+    <h2 class="fw-bold">People Who Liked You</h2>
+    <p class="text-muted mb-0">
+      These users have liked your profile.
+    </p>
+  </section>
+
+  <section class="mt-5">
+    <h4 class="fw-bold mb-4">Your Matches</h4>
+
+    <div class="row g-4" id="likedYouList">
+      <p>Loading profiles...</p>
+    </div>
+  </section>
+
+  <section class="mt-5">
+    <h4 class="fw-bold mb-4">People You Liked</h4>
+    <div class="row g-4" id="youLikedList">
+        <p>Loading profiles...</p>
+    </div>
+  </section>
+
+</main>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/matches.js') }}"></script>
+{% endblock %}

--- a/app/templates/myprofile.html
+++ b/app/templates/myprofile.html
@@ -39,6 +39,17 @@
             form="profileForm"
             hidden
           >
+          <div class="mt-3">
+            <a 
+              href="{{ url_for('matches') }}" 
+              class="btn-like"
+            >
+              Likes received❤️:
+              <span id="displayLikeCount">
+                {{ user.like_count if user else 0 }}
+              </span>
+            </a>
+          </div>
         </div>
         <div id="profileDisplay" class="col-md-8 basic-info">
           <h1 id="displayName">{{ user.display_name or "New Member" }}</h1>


### PR DESCRIPTION
### Frontend

- Created matches.html
- Added two profile sections:
- Users who liked your profile
- Profiles you liked
- Reused the existing profile card UI for consistency
- Added matches.js for dynamic profile loading
- Connected frontend to /api/matches using fetch()
- Added empty-state messages when no profiles exist
- Added clickable “Likes received” badge linking to the Matches page
- Styled likes badge to visually match the existing Like button

### Backend

- Added /matches route to render the matches page
- Added /api/matches API endpoint
- Implemented logic for:
- retrieving profiles that liked the current user
- retrieving profiles the current user liked
- Converted profile data using profile_to_card()
- Returned match data as JSON for frontend rendering

### General

- Reused shared base.html layout and navbar
- Ensured login-required access for matches-related routes
- Improved page organization by separating matches logic into matches.js