### PR TITLE
Fix the story-card image bug

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -753,7 +753,7 @@ def update_story():
         os.makedirs(upload_folder, exist_ok=True)
 
         image_file.save(os.path.join(upload_folder, filename))
-        story.image_path = os.path.join(upload_subdir, filename)
+        story.image_path = f"{upload_subdir}/{filename}" # Fix image upload bug on Windows OS
 
     db.session.commit()
 


### PR DESCRIPTION
## Description
This PR fixed the story-card image uploading bug in #87 .

## Main changes:
Update the stored image URL from using `os.path.join()` to `f"{upload_subdir}/{filename}"`.

## Reason
In Windows system, using `os.path.join()` may create backslashes `\`, which can be encoded as `%5C` in the browser and cause static image 404 errors. Therefore, we replaced it with an explicit forward-slash path so the stored image path remains URL-safe and works consistently across operating systems.