### PR TITLE
Update featured profiles selection logic on index page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -238,7 +238,25 @@ def profile_required(view_func):
 def get_feature_profile():
     featured_profiles = (
         Profile.query
-        .order_by(db.func.random())
+        .outerjoin(Likes, Likes.liked_id == Profile.id)
+        .filter(
+            Profile.display_name.isnot(None),
+            Profile.display_name != "",
+            Profile.age.isnot(None),
+            Profile.gender.isnot(None),
+            Profile.gender != "",
+            Profile.orientation.isnot(None),
+            Profile.orientation != "",
+            Profile.location_text.isnot(None),
+            Profile.location_text != "",
+            Profile.latitude.isnot(None),
+            Profile.longitude.isnot(None),
+            Profile.place_id.isnot(None),
+            Profile.place_id != "",
+            Profile.interests.any(),
+        )
+        .group_by(Profile.id)
+        .order_by(db.func.count(Likes.id).desc(), Profile.id.asc())
         .limit(3)
         .all())
     return [profile_to_card(profile) for profile in featured_profiles]


### PR DESCRIPTION
## Description

This PR updates the featured profiles section on the index page to show the most liked complete profiles instead of random profiles.

## Main Changes

- Updated the featured profiles query on the index page.
- Updated the selection logic from three random profiles to the top three profiles ranked by received likes.
- Added filtering to exclude incomplete profiles from the featured profiles section.
- Applied profile completeness checks directly in the database query for better performance.

## Result

The index page now displays the top three complete profiles with the highest number of received likes, making the featured profiles section more meaningful.

## Notes

The existing `is_complete` property was not used in the query because it is a Python-level property, not a SQL-level filter. Using it would require loading all profiles into memory before filtering them, which is less efficient.

Instead, the required completeness conditions are checked directly in the database query, allowing the database to filter profiles more efficiently.