### PR TITLE
Unit test for password mismatch

### DIFF
--- a/tests/test_unit_passwordmismatch.py
+++ b/tests/test_unit_passwordmismatch.py
@@ -1,0 +1,30 @@
+import pytest
+from app import app, db
+from app.models import User
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+    with app.test_client() as client:
+        with app.app_context():
+            db.create_all()
+        yield client
+        with app.app_context():
+            db.drop_all()
+
+
+def test_signup_password_mismatch(client):
+    response = client.post("/signup", data={
+        "email": "test2@example.com",
+        "password": "password123",
+        "confirm_password": "wrongpass",
+        "g-recaptcha-response": "test"
+    })
+
+    assert b"Passwords do not match" in response.data
+
+
+


### PR DESCRIPTION
This pull request introduces a new unit test to validate the signup form password confirmation logic. It ensures that the backend correctly rejects signup attempts when the password and confirm password fields do not match.

The test also includes a properly configured Flask test client fixture with an isolated in-memory SQLite database to ensure test independence.

Signup Password Mismatch Test

> - Validates that backend rejects mismatched passwords
> - Ensures correct error message is returned in response