### PR TITLE
'Like' selenium test

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import flash, render_template, jsonify, request, redirect, url_for, current_app
+from flask import flash, render_template, jsonify, request, redirect, url_for, current_app, abort
 
 from app import app, db
 import os
@@ -619,7 +619,9 @@ def profile():
 @login_required
 @profile_required
 def profile_detail(profile_id):
-    profile = Profile.query.get_or_404(profile_id)
+    profile = db.session.get(Profile, profile_id)
+    if profile is None:
+        abort(404)
     current_profile = current_user.profile
 
     is_liked = Likes.query.filter_by(
@@ -663,7 +665,9 @@ def profile_detail(profile_id):
 @profile_required
 def handle_like(profile_id):
     current_profile = current_user.profile
-    liked_profile = Profile.query.get_or_404(profile_id)
+    liked_profile = db.session.get(Profile, profile_id)
+    if liked_profile is None:
+        abort(404)
 
     if liked_profile.id == current_profile.id:
         return jsonify({"status": "error", "message": "You cannot like yourself."}), 400

--- a/tests/test_selenium_like.py
+++ b/tests/test_selenium_like.py
@@ -1,0 +1,65 @@
+import pytest
+
+selenium = pytest.importorskip("selenium")
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from app import app, db
+from app.models import Profile, Likes
+
+
+def test_like_creates_db_entry(live_server_url, browser, logged_in_homepage_users):
+    # Find the profile ids created by the fixture
+    with app.app_context():
+        current_profile = Profile.query.filter_by(display_name="Test Home User").first()
+        assert current_profile is not None
+        target_profile = Profile.query.filter_by(display_name="Recommended Tester").first()
+        assert target_profile is not None
+
+    # Open main page and login
+    browser.get(live_server_url + "/")
+
+    WebDriverWait(browser, 5).until(
+        EC.element_to_be_clickable((By.ID, "openLogin"))
+    ).click()
+
+    email_input = WebDriverWait(browser, 5).until(
+        EC.visibility_of_element_located((By.ID, "email"))
+    )
+    email_input.send_keys(logged_in_homepage_users["email"])
+    browser.find_element(By.ID, "password").send_keys(logged_in_homepage_users["password"])
+    browser.find_element(By.CSS_SELECTOR, ".login-btn").click()
+
+    WebDriverWait(browser, 5).until(EC.url_contains("/home"))
+
+    # Navigate to the target profile's page
+    browser.get(live_server_url + f"/profile/{target_profile.id}")
+
+    like_btn = WebDriverWait(browser, 5).until(
+        EC.element_to_be_clickable((By.ID, "likeBtn"))
+    )
+
+    # Ensure initial state is not liked
+    assert "Liked" not in like_btn.text
+
+    # Click like and wait for UI to update
+    like_btn.click()
+
+    WebDriverWait(browser, 5).until(
+        lambda drv: "Liked" in drv.find_element(By.ID, "likeBtn").text
+    )
+
+    # Verify DB entry
+    with app.app_context():
+        like_entry = Likes.query.filter_by(
+            liker_id=current_profile.id,
+            liked_id=target_profile.id
+        ).first()
+
+        assert like_entry is not None
+
+        # Clean up the like so tests are idempotent
+        db.session.delete(like_entry)
+        db.session.commit()


### PR DESCRIPTION
## Summary

Updated legacy SQLAlchemy query usage to improve compatibility with SQLAlchemy 2.x.

## Changes

* Replaced deprecated `.query.get()` usage with `db.session.get()`
* Replaced `.get_or_404()` logic with `db.session.get()` plus `abort(404)`
* Added/confirmed `abort` import where needed
* Preserved existing 404 behavior for missing records

## Purpose

Removes SQLAlchemy legacy API warnings and keeps database access consistent with the newer SQLAlchemy 2.x style.

## Testing

* Confirmed related tests pass
* Verified like functionality still creates database entries correctly
