### PR TITLE
Fix messaging bug and update the conversation logic

### DIFF
--- a/app/conversations.py
+++ b/app/conversations.py
@@ -1,0 +1,45 @@
+from app import db
+from app.models import Conversation
+from sqlalchemy import and_, or_
+
+
+def ordered_profile_ids(profile_a_id, profile_b_id):
+    profile_a_id = int(profile_a_id)
+    profile_b_id = int(profile_b_id)
+
+    if profile_a_id < profile_b_id:
+        return profile_a_id, profile_b_id
+
+    return profile_b_id, profile_a_id
+
+
+def get_or_create_conversation(profile_a_id, profile_b_id, commit=True):
+    profile1_id, profile2_id = ordered_profile_ids(profile_a_id, profile_b_id)
+
+    conversation = Conversation.query.filter(or_(
+        and_(
+            Conversation.profile1_id == profile1_id,
+            Conversation.profile2_id == profile2_id
+        ),
+        and_(
+            Conversation.profile1_id == profile2_id,
+            Conversation.profile2_id == profile1_id
+        )
+    )).first()
+
+    if conversation:
+        return conversation
+
+    conversation = Conversation(
+        profile1_id=profile1_id,
+        profile2_id=profile2_id
+    )
+
+    db.session.add(conversation)
+
+    if commit:
+        db.session.commit()
+    else:
+        db.session.flush()
+
+    return conversation

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,6 +5,7 @@ import os
 
 
 from sqlalchemy import or_
+from app.conversations import get_or_create_conversation
 from app.models import Profile, Interest, User, Likes, Story, Conversation
 
 from math import radians, sin, cos, sqrt, atan2
@@ -686,8 +687,19 @@ def handle_like(profile_id):
                 liker_id=current_profile.id,
                 liked_id=liked_profile.id
             ))
-            db.session.commit()
-        return jsonify({"status": "success", "is_liked": True}), 200
+
+        conversation = get_or_create_conversation(
+            current_profile.id,
+            liked_profile.id,
+            commit=False
+        )
+        db.session.commit()
+
+        return jsonify({
+            "status": "success",
+            "is_liked": True,
+            "conversation_id": conversation.id
+        }), 200
 
     if action == "unlike":
         if existing_like:

--- a/app/sockets.py
+++ b/app/sockets.py
@@ -2,39 +2,8 @@ from flask_login import current_user
 from flask_socketio import join_room, emit, disconnect
 
 from app import socketio, db
-from app.models import Profile, Conversation, Message
-
-
-def ordered_profile_ids(profile_a_id, profile_b_id):
-    profile_a_id = int(profile_a_id)
-    profile_b_id = int(profile_b_id)
-
-    if profile_a_id < profile_b_id:
-        return profile_a_id, profile_b_id
-
-    return profile_b_id, profile_a_id
-
-
-def get_or_create_conversation(profile_a_id, profile_b_id):
-    profile1_id, profile2_id = ordered_profile_ids(profile_a_id, profile_b_id)
-
-    conversation = Conversation.query.filter_by(
-        profile1_id=profile1_id,
-        profile2_id=profile2_id
-    ).first()
-
-    if conversation:
-        return conversation
-
-    conversation = Conversation(
-        profile1_id=profile1_id,
-        profile2_id=profile2_id
-    )
-
-    db.session.add(conversation)
-    db.session.commit()
-
-    return conversation
+from app.conversations import get_or_create_conversation
+from app.models import Profile, Message
 
 
 def get_current_profile():

--- a/app/sockets.py
+++ b/app/sockets.py
@@ -1,8 +1,8 @@
-from flask import session
+from flask_login import current_user
 from flask_socketio import join_room, emit, disconnect
 
 from app import socketio, db
-from app.models import Profile, Conversation, Message, User
+from app.models import Profile, Conversation, Message
 
 
 def ordered_profile_ids(profile_a_id, profile_b_id):
@@ -38,17 +38,10 @@ def get_or_create_conversation(profile_a_id, profile_b_id):
 
 
 def get_current_profile():
-    user_id = session.get("user_id")
-
-    if not user_id:
+    if not current_user.is_authenticated:
         return None
 
-    user = db.session.get(User, user_id)
-
-    if not user:
-        return None
-
-    return user.profile
+    return current_user.profile
 
 
 def profile_room(profile_id):

--- a/app/templates/messages.html
+++ b/app/templates/messages.html
@@ -68,7 +68,7 @@
           <div class="chat-person">
             <img
               id="activeContactImage"
-              src="{{ url_for('static', filename='default-profile.png') }}"
+              src="{{ url_for('static', filename='images/default-profile.png') }}"
               alt=""
             >
             <div>

--- a/tests/unit/test_unit_like_conversation.py
+++ b/tests/unit/test_unit_like_conversation.py
@@ -1,0 +1,241 @@
+from uuid import uuid4
+
+from sqlalchemy import and_, or_
+
+from app import app, db
+from app.models import Conversation, Interest, Likes, Profile, User
+
+
+def create_complete_profile(email, display_name, interest):
+    user = User(email=email)
+    user.set_password("Password123")
+    db.session.add(user)
+    db.session.flush()
+
+    profile = Profile(
+        user_id=user.id,
+        display_name=display_name,
+        age=24,
+        gender="female",
+        orientation="straight",
+        location_text="Perth WA",
+        latitude=-31.9523,
+        longitude=115.8613,
+        place_id=f"place-{uuid4().hex}",
+        bio="Ready to chat.",
+    )
+    profile.interests.append(interest)
+    db.session.add(profile)
+
+    return user, profile
+
+
+def test_liking_profile_creates_conversation_once():
+    unique_id = uuid4().hex
+
+    with app.app_context():
+        interest = Interest.query.filter_by(name="Sports").first()
+        if not interest:
+            interest = Interest(name="Sports")
+            db.session.add(interest)
+            db.session.flush()
+
+        current_user, current_profile = create_complete_profile(
+            f"like-conversation-user-{unique_id}@example.com",
+            "Like Conversation User",
+            interest
+        )
+        _, liked_profile = create_complete_profile(
+            f"like-conversation-contact-{unique_id}@example.com",
+            "Like Conversation Contact",
+            interest
+        )
+        db.session.commit()
+
+        current_profile_id = current_profile.id
+        liked_profile_id = liked_profile.id
+        email = current_user.email
+
+    client = app.test_client()
+    login_response = client.post(
+        "/login",
+        data={
+            "email": email,
+            "password": "Password123",
+        },
+    )
+
+    assert login_response.status_code == 302
+
+    first_response = client.post(
+        f"/profile/{liked_profile_id}/like",
+        json={"action": "like"},
+    )
+    second_response = client.post(
+        f"/profile/{liked_profile_id}/like",
+        json={"action": "like"},
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+
+    with app.app_context():
+        like = Likes.query.filter_by(
+            liker_id=current_profile_id,
+            liked_id=liked_profile_id
+        ).first()
+
+        profile1_id, profile2_id = sorted([current_profile_id, liked_profile_id])
+        conversations = Conversation.query.filter_by(
+            profile1_id=profile1_id,
+            profile2_id=profile2_id
+        ).all()
+
+        assert like is not None
+        assert len(conversations) == 1
+        assert first_response.get_json()["conversation_id"] == conversations[0].id
+        assert second_response.get_json()["conversation_id"] == conversations[0].id
+
+
+def test_liking_profile_reuses_existing_reverse_conversation():
+    unique_id = uuid4().hex
+
+    with app.app_context():
+        interest = Interest.query.filter_by(name="Sports").first()
+        if not interest:
+            interest = Interest(name="Sports")
+            db.session.add(interest)
+            db.session.flush()
+
+        current_user, current_profile = create_complete_profile(
+            f"reverse-conversation-user-{unique_id}@example.com",
+            "Reverse Conversation User",
+            interest
+        )
+        _, liked_profile = create_complete_profile(
+            f"reverse-conversation-contact-{unique_id}@example.com",
+            "Reverse Conversation Contact",
+            interest
+        )
+        db.session.flush()
+
+        existing_conversation = Conversation(
+            profile1_id=liked_profile.id,
+            profile2_id=current_profile.id
+        )
+        db.session.add(existing_conversation)
+        db.session.commit()
+
+        current_profile_id = current_profile.id
+        liked_profile_id = liked_profile.id
+        conversation_id = existing_conversation.id
+        email = current_user.email
+
+    client = app.test_client()
+    login_response = client.post(
+        "/login",
+        data={
+            "email": email,
+            "password": "Password123",
+        },
+    )
+
+    assert login_response.status_code == 302
+
+    response = client.post(
+        f"/profile/{liked_profile_id}/like",
+        json={"action": "like"},
+    )
+
+    assert response.status_code == 200
+
+    with app.app_context():
+        conversations = Conversation.query.filter(or_(
+            and_(
+                Conversation.profile1_id == current_profile_id,
+                Conversation.profile2_id == liked_profile_id
+            ),
+            and_(
+                Conversation.profile1_id == liked_profile_id,
+                Conversation.profile2_id == current_profile_id
+            )
+        )).all()
+
+        assert len(conversations) == 1
+        assert response.get_json()["conversation_id"] == conversation_id
+
+
+def test_like_back_reuses_existing_conversation():
+    unique_id = uuid4().hex
+
+    with app.app_context():
+        interest = Interest.query.filter_by(name="Sports").first()
+        if not interest:
+            interest = Interest(name="Sports")
+            db.session.add(interest)
+            db.session.flush()
+
+        user_a, profile_a = create_complete_profile(
+            f"like-back-a-{unique_id}@example.com",
+            "Like Back User A",
+            interest
+        )
+        user_b, profile_b = create_complete_profile(
+            f"like-back-b-{unique_id}@example.com",
+            "Like Back User B",
+            interest
+        )
+        db.session.commit()
+
+        profile_a_id = profile_a.id
+        profile_b_id = profile_b.id
+        email_a = user_a.email
+        email_b = user_b.email
+
+    client_a = app.test_client()
+    login_a_response = client_a.post(
+        "/login",
+        data={
+            "email": email_a,
+            "password": "Password123",
+        },
+    )
+    assert login_a_response.status_code == 302
+
+    a_likes_b_response = client_a.post(
+        f"/profile/{profile_b_id}/like",
+        json={"action": "like"},
+    )
+    assert a_likes_b_response.status_code == 200
+    conversation_id = a_likes_b_response.get_json()["conversation_id"]
+
+    client_b = app.test_client()
+    login_b_response = client_b.post(
+        "/login",
+        data={
+            "email": email_b,
+            "password": "Password123",
+        },
+    )
+    assert login_b_response.status_code == 302
+
+    b_likes_a_response = client_b.post(
+        f"/profile/{profile_a_id}/like",
+        json={"action": "like"},
+    )
+    assert b_likes_a_response.status_code == 200
+
+    with app.app_context():
+        conversations = Conversation.query.filter(or_(
+            and_(
+                Conversation.profile1_id == profile_a_id,
+                Conversation.profile2_id == profile_b_id
+            ),
+            and_(
+                Conversation.profile1_id == profile_b_id,
+                Conversation.profile2_id == profile_a_id
+            )
+        )).all()
+
+        assert len(conversations) == 1
+        assert b_likes_a_response.get_json()["conversation_id"] == conversation_id

--- a/tests/unit/test_unit_messages_socket_auth.py
+++ b/tests/unit/test_unit_messages_socket_auth.py
@@ -1,0 +1,48 @@
+from uuid import uuid4
+
+from app import app, db, socketio
+from app.models import Profile, User
+
+
+def test_logged_in_user_can_connect_to_messages_socket():
+    password = "Password123"
+    email = f"socket-user-{uuid4().hex}@example.com"
+
+    with app.app_context():
+        user = User(email=email)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.flush()
+
+        db.session.add(
+            Profile(
+                user_id=user.id,
+                display_name="Socket User",
+                age=22,
+                gender="male",
+                orientation="straight",
+                location_text="Perth WA",
+                latitude=-31.9523,
+                longitude=115.8613,
+                place_id=f"socket-user-{uuid4().hex}",
+            )
+        )
+        db.session.commit()
+
+    flask_client = app.test_client()
+    response = flask_client.post(
+        "/login",
+        data={
+            "email": email,
+            "password": password,
+        },
+    )
+
+    assert response.status_code == 302
+
+    socket_client = socketio.test_client(
+        app,
+        flask_test_client=flask_client,
+    )
+
+    assert socket_client.is_connected()


### PR DESCRIPTION
## Description

This PR fixes Socket.IO authentication for the messages feature and updates the conversation creation logic to better support likes and messaging.

## Main Changes

- Fixed messages Socket.IO authentication by using `flask_login.current_user` instead of manually reading `flask.session["user_id"]`.
- Fixed the default profile image path in `messages.html`.
- Added `app/conversations.py` to centralize conversation lookup and creation logic.
- Updated the like logic so liking a user automatically creates or reuses a conversation.
- Prevented duplicate conversations by checking both user directions before creating a new conversation.
- Kept conversations after unlike; only the like relationship is removed.
- Updated `app/sockets.py` to reuse the shared conversation helper.
- Added unit tests for messages socket authentication and like-based conversation creation.

## Tests

- Added `tests/unit/test_unit_messages_socket_auth.py`.
- Added `tests/unit/test_unit_like_conversation.py`.
- Verified that:
  - logged-in users can connect to the messages socket;
  - liking a user creates a conversation;
  - repeated likes do not create duplicate conversations;
  - existing reverse-direction conversations are reused;
  - mutual likes reuse the same conversation.