### PR TITLE
Remove Redundant and Unused CSS Selectors

### DIFF
--- a/app/static/css/profile.css
+++ b/app/static/css/profile.css
@@ -134,16 +134,7 @@
   min-height: 110px;
 }
 
-.profile-popup .checkbox-group {
-    display: flex;
-    align-items: center;
-    margin-bottom: 15px;
-}
 
-.profile-popup .checkbox-group input[type="checkbox"] {
-    width: auto; /* Overrides the 100% width from your general input style */
-    margin-bottom: 0;
-}
 
 .input-hint {
     font-size: 12px;

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -60,12 +60,7 @@ body {
   color: #ffd6e0;
 }
 
-/* Navbar button */
-.navbar-custom .btn {
-  border-radius: 25px;
-  padding: 6px 16px;
-  font-size: 0.9rem;
-}
+
 
 /* Login buttton */
 .btn-login {

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -132,19 +132,7 @@ h5 {
   background-color: #5a54d1;
 }
 
-/* Outline button */
-.btn-outline-custom {
-  background-color: transparent;
-  color: var(--primary-color);
-  border: 2px solid var(--primary-color);
-  padding: 10px 20px;
-  border-radius: 30px;
-}
 
-.btn-outline-custom:hover {
-  background-color: var(--primary-color);
-  color: var(--white);
-}
 
 /* Card */
 


### PR DESCRIPTION
This PR removes redundant and likely unused CSS selectors from the project stylesheet files to improve maintainability and reduce unnecessary styling code.

## Changes Made

### Removed from `styles.css`
- `.btn-outline-custom`
- `.btn-outline-custom:hover`
- `.navbar-custom .btn`

### Removed from `profile.css`
- `.checkbox-group`
- `.input-hint`
